### PR TITLE
Update dependencies and enhance chart loading functionality

### DIFF
--- a/brows.html
+++ b/brows.html
@@ -80,7 +80,7 @@ when <!DOCTYPE html>
   <ul id="mapList"></ul>
 
   <script>
-    const API_BASE_URL = 'https://bug-free-space-succotash-q77746g7pjrhx47p-3001.app.github.dev/api';
+    const API_BASE_URL = 'https://psychic-space-winner-wp6r9r97qv6hvgw4-3001.app.github.dev/api';
 
     // Check login status
     function getCurrentUser() {
@@ -139,30 +139,21 @@ when <!DOCTYPE html>
           loadBtn.addEventListener('click', () => {
             // Load map data into editor2.html via URL parameter
             const encodedData = btoa(encodeURIComponent(JSON.stringify(map.chartData)));
-            const url = `editor2.html?chart=${encodedData}`;
+            let url = `editor2.html?chart=${encodedData}`;
+            if (map.song) {
+              url += `&song=${encodeURIComponent(map.song)}`;
+            }
             window.location.href = url;
           });
-
-          // Map of song titles to audio file paths
-          const songMap = {
-            "Neon Dreams": "/songs/song.mp3",
-            "All My Stars": "/songs/song2.mp3",
-            "Digital Sunset": "/songs/song3.mp3",
-            "Cyber Rush": "/songs/song4.mp3",
-            "Night Drive": "/songs/song5.mp3",
-            "Never": "/songs/song6.mp3",
-            "Battle Under A Broken Sky": "/songs/battleundersky.mp3",
-            "Press X Twice": "/songs/Press X Twice.mp3",
-            "Song 7": "/songs/videoplayback1.mp3",
-            "Mega Man 2 — Staff Roll (piano)": "/songs/Mega Man 2 — Staff Roll (piano).mp3"
-          };
 
           const playBtn = document.createElement('button');
           playBtn.textContent = 'Play';
           playBtn.addEventListener('click', () => {
-            // Load map data into play.html via mapId parameter
-            const songUrl = songMap[map.title] || '';
-            const url = `play.html?mapId=${map.id}&song=${encodeURIComponent(songUrl)}`;
+            // Load map data into play.html via mapId and song parameter
+            let url = `play.html?mapId=${map.id}`;
+            if (map.song) {
+              url += `&song=${encodeURIComponent(map.song)}`;
+            }
             window.location.href = url;
           });
 

--- a/editor2.html
+++ b/editor2.html
@@ -242,9 +242,12 @@
         alert("No chart data to export.");
         return;
       }
-
-      // Format chart data as plain text
-      const textData = chartData
+      const song = songSelector.value;
+      let textData = '';
+      if (song && song.trim() !== '') {
+        textData += `Song: ${song}\n`;
+      }
+      textData += chartData
         .map((note) =>
           note.type === "slider"
             ? `Slider: StartTime: ${note.startTime}, EndTime: ${note.endTime}, Key: ${note.note}`
@@ -371,6 +374,11 @@
         alert('No chart data to publish.');
         return;
       }
+      const song = songSelector.value;
+      if (!song || song.trim() === '') {
+        alert('Please select a song before publishing your map.');
+        return;
+      }
       const title = prompt('Enter a title for your map:');
       if (!title) {
         alert('Publishing cancelled: title is required.');
@@ -382,13 +390,13 @@
         return;
       }
       try {
-        const response = await fetch('https://bug-free-space-succotash-q77746g7pjrhx47p-3001.app.github.dev/api/maps', {
+        const response = await fetch('https://psychic-space-winner-wp6r9r97qv6hvgw4-3001.app.github.dev/api/maps', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
             'Authorization': 'Bearer ' + token
           },
-          body: JSON.stringify({ title, chartData })
+          body: JSON.stringify({ title, chartData, song })
         });
         if (response.ok) {
           alert('Map published successfully!');

--- a/login.html
+++ b/login.html
@@ -87,7 +87,7 @@
       }
 
       try {
-        const response = await fetch('https://bug-free-space-succotash-q77746g7pjrhx47p-3001.app.github.dev/api/login', {
+        const response = await fetch('https://psychic-space-winner-wp6r9r97qv6hvgw4-3001.app.github.dev/api/login', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ username, password })

--- a/maps.json
+++ b/maps.json
@@ -1082,5 +1082,3035 @@
       }
     ],
     "songUrl": ""
+  },
+  {
+    "id": 1754860426785,
+    "title": "new make test1",
+    "author": "miles",
+    "chartData": [
+      {
+        "time": "2.20",
+        "note": "j"
+      },
+      {
+        "time": "3.31",
+        "note": "d"
+      },
+      {
+        "time": "3.59",
+        "note": "k"
+      },
+      {
+        "time": "4.01",
+        "note": "j"
+      },
+      {
+        "time": "4.50",
+        "note": "f"
+      },
+      {
+        "time": "4.77",
+        "note": "k"
+      },
+      {
+        "time": "4.92",
+        "note": "f"
+      },
+      {
+        "time": "5.53",
+        "note": "j"
+      },
+      {
+        "type": "slider",
+        "startTime": "7.06",
+        "endTime": "7.51",
+        "note": "k"
+      },
+      {
+        "type": "slider",
+        "startTime": "7.07",
+        "endTime": "7.77",
+        "note": "d"
+      },
+      {
+        "type": "slider",
+        "startTime": "7.49",
+        "endTime": "7.84",
+        "note": "j"
+      },
+      {
+        "type": "slider",
+        "startTime": "7.76",
+        "endTime": "8.09",
+        "note": "f"
+      },
+      {
+        "type": "slider",
+        "startTime": "7.99",
+        "endTime": "8.34",
+        "note": "k"
+      },
+      {
+        "time": "8.46",
+        "note": "d"
+      },
+      {
+        "type": "slider",
+        "startTime": "8.43",
+        "endTime": "8.74",
+        "note": "j"
+      },
+      {
+        "time": "8.90",
+        "note": "f"
+      },
+      {
+        "type": "slider",
+        "startTime": "8.88",
+        "endTime": "9.24",
+        "note": "k"
+      },
+      {
+        "type": "slider",
+        "startTime": "9.08",
+        "endTime": "10.58",
+        "note": "d"
+      },
+      {
+        "type": "slider",
+        "startTime": "9.56",
+        "endTime": "10.59",
+        "note": "j"
+      },
+      {
+        "time": "10.82",
+        "note": "k"
+      },
+      {
+        "type": "slider",
+        "startTime": "10.79",
+        "endTime": "11.30",
+        "note": "j"
+      },
+      {
+        "type": "slider",
+        "startTime": "10.57",
+        "endTime": "11.46",
+        "note": "f"
+      },
+      {
+        "type": "slider",
+        "startTime": "11.28",
+        "endTime": "11.71",
+        "note": "k"
+      },
+      {
+        "time": "11.80",
+        "note": "f"
+      },
+      {
+        "time": "11.99",
+        "note": "j"
+      },
+      {
+        "time": "12.12",
+        "note": "d"
+      },
+      {
+        "time": "12.41",
+        "note": "k"
+      },
+      {
+        "time": "12.50",
+        "note": "f"
+      },
+      {
+        "type": "slider",
+        "startTime": "12.80",
+        "endTime": "13.42",
+        "note": "k"
+      },
+      {
+        "type": "slider",
+        "startTime": "12.79",
+        "endTime": "13.44",
+        "note": "f"
+      },
+      {
+        "time": "14.57",
+        "note": "d"
+      },
+      {
+        "time": "14.58",
+        "note": "j"
+      },
+      {
+        "time": "14.98",
+        "note": "f"
+      },
+      {
+        "time": "15.04",
+        "note": "k"
+      },
+      {
+        "time": "15.24",
+        "note": "d"
+      },
+      {
+        "time": "15.26",
+        "note": "j"
+      },
+      {
+        "time": "15.39",
+        "note": "d"
+      },
+      {
+        "time": "15.86",
+        "note": "k"
+      },
+      {
+        "time": "16.07",
+        "note": "f"
+      },
+      {
+        "time": "16.27",
+        "note": "j"
+      },
+      {
+        "time": "16.53",
+        "note": "d"
+      },
+      {
+        "time": "16.82",
+        "note": "k"
+      },
+      {
+        "time": "17.01",
+        "note": "f"
+      },
+      {
+        "time": "17.24",
+        "note": "j"
+      },
+      {
+        "time": "17.46",
+        "note": "d"
+      },
+      {
+        "type": "slider",
+        "startTime": "17.45",
+        "endTime": "17.95",
+        "note": "k"
+      },
+      {
+        "type": "slider",
+        "startTime": "17.87",
+        "endTime": "18.23",
+        "note": "f"
+      },
+      {
+        "type": "slider",
+        "startTime": "18.17",
+        "endTime": "18.61",
+        "note": "j"
+      },
+      {
+        "time": "18.85",
+        "note": "d"
+      },
+      {
+        "time": "19.12",
+        "note": "k"
+      },
+      {
+        "time": "19.26",
+        "note": "f"
+      },
+      {
+        "time": "19.55",
+        "note": "j"
+      },
+      {
+        "time": "19.67",
+        "note": "d"
+      },
+      {
+        "time": "20.09",
+        "note": "k"
+      },
+      {
+        "time": "20.35",
+        "note": "k"
+      },
+      {
+        "time": "20.63",
+        "note": "f"
+      },
+      {
+        "time": "20.82",
+        "note": "j"
+      },
+      {
+        "time": "20.97",
+        "note": "d"
+      },
+      {
+        "time": "21.41",
+        "note": "d"
+      },
+      {
+        "time": "21.45",
+        "note": "k"
+      },
+      {
+        "time": "21.90",
+        "note": "f"
+      },
+      {
+        "time": "21.93",
+        "note": "j"
+      },
+      {
+        "time": "22.41",
+        "note": "d"
+      },
+      {
+        "time": "22.44",
+        "note": "k"
+      },
+      {
+        "time": "23.98",
+        "note": "f"
+      },
+      {
+        "time": "24.00",
+        "note": "k"
+      },
+      {
+        "time": "24.26",
+        "note": "f"
+      },
+      {
+        "time": "24.32",
+        "note": "k"
+      },
+      {
+        "time": "24.52",
+        "note": "d"
+      },
+      {
+        "time": "24.56",
+        "note": "j"
+      },
+      {
+        "time": "24.81",
+        "note": "f"
+      },
+      {
+        "time": "24.83",
+        "note": "k"
+      },
+      {
+        "time": "25.22",
+        "note": "d"
+      },
+      {
+        "time": "25.23",
+        "note": "j"
+      },
+      {
+        "time": "25.70",
+        "note": "f"
+      },
+      {
+        "time": "25.79",
+        "note": "k"
+      },
+      {
+        "time": "26.11",
+        "note": "f"
+      },
+      {
+        "time": "26.13",
+        "note": "j"
+      },
+      {
+        "time": "26.35",
+        "note": "d"
+      },
+      {
+        "time": "26.45",
+        "note": "k"
+      },
+      {
+        "time": "26.67",
+        "note": "f"
+      },
+      {
+        "time": "26.94",
+        "note": "j"
+      },
+      {
+        "time": "27.09",
+        "note": "d"
+      },
+      {
+        "time": "27.44",
+        "note": "k"
+      },
+      {
+        "time": "27.49",
+        "note": "f"
+      },
+      {
+        "time": "27.75",
+        "note": "d"
+      },
+      {
+        "time": "27.75",
+        "note": "j"
+      },
+      {
+        "time": "27.98",
+        "note": "f"
+      },
+      {
+        "time": "28.45",
+        "note": "d"
+      },
+      {
+        "time": "28.48",
+        "note": "k"
+      },
+      {
+        "time": "28.87",
+        "note": "f"
+      },
+      {
+        "time": "28.90",
+        "note": "j"
+      },
+      {
+        "time": "29.34",
+        "note": "d"
+      },
+      {
+        "time": "29.39",
+        "note": "k"
+      },
+      {
+        "time": "29.74",
+        "note": "f"
+      },
+      {
+        "time": "29.75",
+        "note": "j"
+      },
+      {
+        "time": "29.98",
+        "note": "f"
+      },
+      {
+        "time": "29.99",
+        "note": "j"
+      }
+    ]
+  },
+  {
+    "id": 1754860636490,
+    "title": "new song test2",
+    "author": "miles",
+    "chartData": [
+      {
+        "time": "1.51",
+        "note": "j"
+      },
+      {
+        "time": "1.59",
+        "note": "f"
+      },
+      {
+        "time": "1.78",
+        "note": "d"
+      },
+      {
+        "time": "1.79",
+        "note": "k"
+      },
+      {
+        "time": "2.26",
+        "note": "j"
+      },
+      {
+        "time": "2.27",
+        "note": "f"
+      },
+      {
+        "time": "2.43",
+        "note": "f"
+      },
+      {
+        "time": "2.44",
+        "note": "j"
+      },
+      {
+        "time": "2.88",
+        "note": "k"
+      },
+      {
+        "time": "2.90",
+        "note": "d"
+      },
+      {
+        "time": "3.07",
+        "note": "d"
+      },
+      {
+        "time": "3.09",
+        "note": "k"
+      },
+      {
+        "time": "3.52",
+        "note": "f"
+      },
+      {
+        "time": "3.52",
+        "note": "j"
+      },
+      {
+        "time": "3.70",
+        "note": "f"
+      },
+      {
+        "time": "3.72",
+        "note": "j"
+      },
+      {
+        "time": "4.18",
+        "note": "k"
+      },
+      {
+        "time": "4.19",
+        "note": "d"
+      },
+      {
+        "time": "4.37",
+        "note": "d"
+      },
+      {
+        "time": "4.39",
+        "note": "k"
+      },
+      {
+        "time": "4.84",
+        "note": "f"
+      },
+      {
+        "time": "4.85",
+        "note": "j"
+      },
+      {
+        "time": "5.05",
+        "note": "d"
+      },
+      {
+        "time": "5.10",
+        "note": "k"
+      },
+      {
+        "time": "5.14",
+        "note": "j"
+      },
+      {
+        "time": "5.30",
+        "note": "f"
+      },
+      {
+        "time": "5.44",
+        "note": "j"
+      },
+      {
+        "type": "slider",
+        "startTime": "5.46",
+        "endTime": "5.76",
+        "note": "f"
+      },
+      {
+        "time": "5.99",
+        "note": "k"
+      },
+      {
+        "time": "6.32",
+        "note": "d"
+      },
+      {
+        "time": "6.47",
+        "note": "j"
+      },
+      {
+        "time": "6.64",
+        "note": "f"
+      },
+      {
+        "time": "6.86",
+        "note": "k"
+      },
+      {
+        "time": "6.99",
+        "note": "d"
+      },
+      {
+        "time": "7.16",
+        "note": "j"
+      },
+      {
+        "time": "7.31",
+        "note": "f"
+      },
+      {
+        "time": "7.52",
+        "note": "k"
+      },
+      {
+        "time": "7.61",
+        "note": "d"
+      },
+      {
+        "time": "7.82",
+        "note": "j"
+      },
+      {
+        "time": "7.98",
+        "note": "f"
+      },
+      {
+        "time": "8.26",
+        "note": "k"
+      },
+      {
+        "time": "8.33",
+        "note": "d"
+      },
+      {
+        "time": "8.62",
+        "note": "j"
+      },
+      {
+        "time": "8.87",
+        "note": "f"
+      },
+      {
+        "time": "9.10",
+        "note": "f"
+      },
+      {
+        "time": "9.64",
+        "note": "k"
+      },
+      {
+        "time": "9.75",
+        "note": "d"
+      },
+      {
+        "time": "9.99",
+        "note": "j"
+      },
+      {
+        "time": "10.33",
+        "note": "f"
+      },
+      {
+        "type": "slider",
+        "startTime": "10.32",
+        "endTime": "10.65",
+        "note": "k"
+      },
+      {
+        "time": "10.89",
+        "note": "d"
+      },
+      {
+        "time": "10.90",
+        "note": "j"
+      },
+      {
+        "time": "11.11",
+        "note": "f"
+      },
+      {
+        "time": "11.33",
+        "note": "k"
+      },
+      {
+        "time": "11.35",
+        "note": "d"
+      },
+      {
+        "time": "11.53",
+        "note": "j"
+      },
+      {
+        "time": "11.68",
+        "note": "f"
+      },
+      {
+        "time": "11.89",
+        "note": "k"
+      },
+      {
+        "time": "12.16",
+        "note": "d"
+      },
+      {
+        "time": "12.38",
+        "note": "j"
+      },
+      {
+        "type": "slider",
+        "startTime": "12.32",
+        "endTime": "12.67",
+        "note": "f"
+      },
+      {
+        "time": "12.86",
+        "note": "k"
+      },
+      {
+        "time": "13.00",
+        "note": "d"
+      },
+      {
+        "type": "slider",
+        "startTime": "12.97",
+        "endTime": "13.35",
+        "note": "j"
+      },
+      {
+        "time": "13.50",
+        "note": "f"
+      },
+      {
+        "time": "13.69",
+        "note": "k"
+      },
+      {
+        "time": "13.79",
+        "note": "d"
+      },
+      {
+        "time": "13.96",
+        "note": "j"
+      },
+      {
+        "time": "14.12",
+        "note": "f"
+      },
+      {
+        "time": "14.29",
+        "note": "k"
+      },
+      {
+        "type": "slider",
+        "startTime": "14.24",
+        "endTime": "14.77",
+        "note": "d"
+      },
+      {
+        "time": "14.96",
+        "note": "j"
+      },
+      {
+        "type": "slider",
+        "startTime": "14.92",
+        "endTime": "15.40",
+        "note": "f"
+      },
+      {
+        "time": "15.64",
+        "note": "k"
+      },
+      {
+        "time": "15.77",
+        "note": "f"
+      },
+      {
+        "time": "15.96",
+        "note": "j"
+      },
+      {
+        "time": "16.09",
+        "note": "f"
+      },
+      {
+        "time": "16.30",
+        "note": "k"
+      },
+      {
+        "time": "16.43",
+        "note": "d"
+      },
+      {
+        "time": "16.59",
+        "note": "j"
+      },
+      {
+        "time": "16.75",
+        "note": "f"
+      },
+      {
+        "time": "16.93",
+        "note": "k"
+      },
+      {
+        "time": "17.07",
+        "note": "f"
+      },
+      {
+        "time": "17.17",
+        "note": "j"
+      },
+      {
+        "type": "slider",
+        "startTime": "17.26",
+        "endTime": "17.63",
+        "note": "f"
+      },
+      {
+        "type": "slider",
+        "startTime": "17.64",
+        "endTime": "17.99",
+        "note": "k"
+      },
+      {
+        "time": "18.19",
+        "note": "j"
+      },
+      {
+        "time": "18.36",
+        "note": "d"
+      },
+      {
+        "time": "18.55",
+        "note": "k"
+      },
+      {
+        "time": "18.64",
+        "note": "f"
+      },
+      {
+        "time": "18.83",
+        "note": "j"
+      },
+      {
+        "time": "18.94",
+        "note": "d"
+      },
+      {
+        "time": "19.16",
+        "note": "k"
+      },
+      {
+        "time": "19.25",
+        "note": "f"
+      },
+      {
+        "time": "19.44",
+        "note": "j"
+      },
+      {
+        "time": "19.54",
+        "note": "d"
+      },
+      {
+        "time": "19.81",
+        "note": "k"
+      },
+      {
+        "time": "21.09",
+        "note": "f"
+      },
+      {
+        "time": "21.13",
+        "note": "k"
+      },
+      {
+        "time": "22.43",
+        "note": "d"
+      },
+      {
+        "time": "22.47",
+        "note": "j"
+      },
+      {
+        "time": "22.88",
+        "note": "f"
+      },
+      {
+        "time": "22.93",
+        "note": "k"
+      },
+      {
+        "time": "23.06",
+        "note": "f"
+      },
+      {
+        "time": "23.16",
+        "note": "j"
+      },
+      {
+        "time": "23.55",
+        "note": "k"
+      },
+      {
+        "time": "23.57",
+        "note": "d"
+      },
+      {
+        "time": "23.70",
+        "note": "f"
+      },
+      {
+        "time": "23.74",
+        "note": "j"
+      },
+      {
+        "time": "23.90",
+        "note": "f"
+      },
+      {
+        "time": "24.00",
+        "note": "k"
+      },
+      {
+        "time": "24.13",
+        "note": "f"
+      },
+      {
+        "time": "24.14",
+        "note": "j"
+      },
+      {
+        "time": "24.28",
+        "note": "d"
+      },
+      {
+        "time": "24.31",
+        "note": "k"
+      },
+      {
+        "time": "24.39",
+        "note": "j"
+      },
+      {
+        "time": "24.44",
+        "note": "f"
+      },
+      {
+        "time": "24.52",
+        "note": "j"
+      },
+      {
+        "time": "24.66",
+        "note": "d"
+      },
+      {
+        "time": "24.69",
+        "note": "f"
+      },
+      {
+        "time": "24.82",
+        "note": "k"
+      },
+      {
+        "time": "24.94",
+        "note": "f"
+      },
+      {
+        "time": "25.19",
+        "note": "k"
+      },
+      {
+        "time": "25.48",
+        "note": "d"
+      },
+      {
+        "time": "25.55",
+        "note": "j"
+      },
+      {
+        "time": "25.65",
+        "note": "j"
+      },
+      {
+        "time": "25.69",
+        "note": "d"
+      },
+      {
+        "time": "25.72",
+        "note": "k"
+      },
+      {
+        "time": "26.16",
+        "note": "f"
+      },
+      {
+        "time": "26.21",
+        "note": "k"
+      },
+      {
+        "time": "26.35",
+        "note": "f"
+      },
+      {
+        "time": "26.41",
+        "note": "j"
+      },
+      {
+        "time": "26.56",
+        "note": "d"
+      },
+      {
+        "time": "26.69",
+        "note": "k"
+      },
+      {
+        "time": "26.79",
+        "note": "f"
+      },
+      {
+        "time": "26.89",
+        "note": "j"
+      },
+      {
+        "time": "27.01",
+        "note": "d"
+      },
+      {
+        "time": "27.16",
+        "note": "k"
+      },
+      {
+        "time": "27.28",
+        "note": "f"
+      },
+      {
+        "time": "27.41",
+        "note": "j"
+      },
+      {
+        "time": "27.57",
+        "note": "d"
+      },
+      {
+        "time": "27.79",
+        "note": "k"
+      },
+      {
+        "time": "27.93",
+        "note": "f"
+      },
+      {
+        "time": "28.08",
+        "note": "j"
+      },
+      {
+        "time": "28.27",
+        "note": "f"
+      },
+      {
+        "time": "28.44",
+        "note": "k"
+      },
+      {
+        "time": "28.60",
+        "note": "d"
+      },
+      {
+        "time": "28.76",
+        "note": "j"
+      },
+      {
+        "time": "28.92",
+        "note": "f"
+      },
+      {
+        "time": "29.12",
+        "note": "k"
+      },
+      {
+        "time": "29.28",
+        "note": "f"
+      },
+      {
+        "time": "29.44",
+        "note": "j"
+      },
+      {
+        "time": "29.67",
+        "note": "d"
+      },
+      {
+        "time": "29.99",
+        "note": "k"
+      },
+      {
+        "time": "30.12",
+        "note": "f"
+      },
+      {
+        "time": "30.29",
+        "note": "j"
+      },
+      {
+        "time": "30.46",
+        "note": "d"
+      },
+      {
+        "time": "30.66",
+        "note": "k"
+      },
+      {
+        "time": "30.78",
+        "note": "f"
+      },
+      {
+        "time": "30.94",
+        "note": "j"
+      },
+      {
+        "time": "31.11",
+        "note": "d"
+      },
+      {
+        "time": "31.32",
+        "note": "k"
+      },
+      {
+        "time": "31.46",
+        "note": "f"
+      },
+      {
+        "time": "31.60",
+        "note": "j"
+      },
+      {
+        "time": "31.76",
+        "note": "d"
+      },
+      {
+        "time": "31.97",
+        "note": "k"
+      },
+      {
+        "time": "32.09",
+        "note": "f"
+      },
+      {
+        "time": "32.27",
+        "note": "j"
+      },
+      {
+        "time": "32.56",
+        "note": "f"
+      },
+      {
+        "time": "32.82",
+        "note": "k"
+      },
+      {
+        "time": "32.94",
+        "note": "f"
+      },
+      {
+        "time": "33.12",
+        "note": "j"
+      },
+      {
+        "time": "33.30",
+        "note": "d"
+      },
+      {
+        "time": "33.48",
+        "note": "k"
+      },
+      {
+        "time": "33.64",
+        "note": "f"
+      },
+      {
+        "time": "33.80",
+        "note": "j"
+      },
+      {
+        "time": "33.96",
+        "note": "d"
+      },
+      {
+        "time": "34.15",
+        "note": "k"
+      },
+      {
+        "time": "34.28",
+        "note": "f"
+      },
+      {
+        "time": "34.44",
+        "note": "j"
+      },
+      {
+        "time": "34.60",
+        "note": "d"
+      },
+      {
+        "time": "34.81",
+        "note": "k"
+      },
+      {
+        "time": "34.97",
+        "note": "f"
+      },
+      {
+        "time": "35.27",
+        "note": "j"
+      },
+      {
+        "time": "35.52",
+        "note": "f"
+      },
+      {
+        "time": "35.80",
+        "note": "k"
+      },
+      {
+        "time": "36.00",
+        "note": "f"
+      },
+      {
+        "time": "36.16",
+        "note": "j"
+      },
+      {
+        "time": "36.30",
+        "note": "f"
+      },
+      {
+        "time": "36.46",
+        "note": "k"
+      },
+      {
+        "time": "36.55",
+        "note": "d"
+      },
+      {
+        "time": "36.73",
+        "note": "j"
+      },
+      {
+        "time": "36.96",
+        "note": "f"
+      },
+      {
+        "time": "37.11",
+        "note": "k"
+      },
+      {
+        "time": "37.27",
+        "note": "d"
+      },
+      {
+        "time": "37.46",
+        "note": "j"
+      },
+      {
+        "time": "37.57",
+        "note": "f"
+      }
+    ]
+  },
+  {
+    "id": 1754860852204,
+    "title": "new test 3",
+    "author": "miles",
+    "chartData": [
+      {
+        "time": "1.37",
+        "note": "d"
+      },
+      {
+        "time": "1.52",
+        "note": "k"
+      },
+      {
+        "time": "1.60",
+        "note": "f"
+      },
+      {
+        "time": "1.73",
+        "note": "j"
+      },
+      {
+        "time": "1.86",
+        "note": "d"
+      },
+      {
+        "type": "slider",
+        "startTime": "1.84",
+        "endTime": "2.15",
+        "note": "k"
+      },
+      {
+        "time": "2.42",
+        "note": "f"
+      },
+      {
+        "time": "2.44",
+        "note": "k"
+      },
+      {
+        "time": "2.62",
+        "note": "k"
+      },
+      {
+        "time": "2.73",
+        "note": "d"
+      },
+      {
+        "time": "2.81",
+        "note": "j"
+      },
+      {
+        "time": "3.26",
+        "note": "k"
+      },
+      {
+        "time": "3.28",
+        "note": "f"
+      },
+      {
+        "time": "3.65",
+        "note": "d"
+      },
+      {
+        "time": "3.67",
+        "note": "k"
+      },
+      {
+        "time": "3.85",
+        "note": "j"
+      },
+      {
+        "time": "4.02",
+        "note": "f"
+      },
+      {
+        "type": "slider",
+        "startTime": "3.96",
+        "endTime": "4.39",
+        "note": "k"
+      },
+      {
+        "type": "slider",
+        "startTime": "4.34",
+        "endTime": "4.84",
+        "note": "d"
+      },
+      {
+        "type": "slider",
+        "startTime": "4.78",
+        "endTime": "5.38",
+        "note": "j"
+      },
+      {
+        "time": "5.51",
+        "note": "f"
+      },
+      {
+        "time": "5.63",
+        "note": "j"
+      },
+      {
+        "time": "5.75",
+        "note": "f"
+      },
+      {
+        "time": "5.95",
+        "note": "j"
+      },
+      {
+        "time": "6.08",
+        "note": "d"
+      },
+      {
+        "type": "slider",
+        "startTime": "6.04",
+        "endTime": "6.53",
+        "note": "k"
+      },
+      {
+        "type": "slider",
+        "startTime": "6.18",
+        "endTime": "6.76",
+        "note": "f"
+      },
+      {
+        "time": "6.99",
+        "note": "j"
+      },
+      {
+        "type": "slider",
+        "startTime": "6.90",
+        "endTime": "7.40",
+        "note": "d"
+      },
+      {
+        "type": "slider",
+        "startTime": "7.18",
+        "endTime": "7.54",
+        "note": "k"
+      },
+      {
+        "type": "slider",
+        "startTime": "7.41",
+        "endTime": "7.73",
+        "note": "f"
+      },
+      {
+        "time": "7.92",
+        "note": "j"
+      },
+      {
+        "time": "8.05",
+        "note": "d"
+      },
+      {
+        "time": "8.43",
+        "note": "k"
+      },
+      {
+        "time": "9.11",
+        "note": "j"
+      },
+      {
+        "time": "9.13",
+        "note": "d"
+      },
+      {
+        "time": "9.55",
+        "note": "f"
+      },
+      {
+        "time": "9.69",
+        "note": "k"
+      },
+      {
+        "time": "9.80",
+        "note": "d"
+      },
+      {
+        "time": "9.92",
+        "note": "j"
+      },
+      {
+        "time": "10.04",
+        "note": "f"
+      },
+      {
+        "time": "10.20",
+        "note": "k"
+      },
+      {
+        "time": "10.26",
+        "note": "d"
+      },
+      {
+        "time": "10.30",
+        "note": "f"
+      },
+      {
+        "time": "10.44",
+        "note": "d"
+      },
+      {
+        "time": "10.53",
+        "note": "j"
+      },
+      {
+        "time": "10.93",
+        "note": "f"
+      },
+      {
+        "time": "10.96",
+        "note": "k"
+      },
+      {
+        "time": "11.23",
+        "note": "d"
+      },
+      {
+        "time": "11.25",
+        "note": "j"
+      },
+      {
+        "time": "11.36",
+        "note": "k"
+      },
+      {
+        "time": "11.69",
+        "note": "f"
+      },
+      {
+        "time": "11.74",
+        "note": "k"
+      },
+      {
+        "time": "11.99",
+        "note": "f"
+      },
+      {
+        "time": "12.04",
+        "note": "j"
+      },
+      {
+        "time": "12.61",
+        "note": "d"
+      },
+      {
+        "time": "12.64",
+        "note": "k"
+      },
+      {
+        "time": "13.29",
+        "note": "f"
+      },
+      {
+        "time": "13.35",
+        "note": "j"
+      },
+      {
+        "time": "14.21",
+        "note": "k"
+      },
+      {
+        "time": "14.36",
+        "note": "d"
+      },
+      {
+        "time": "14.45",
+        "note": "j"
+      },
+      {
+        "time": "14.62",
+        "note": "f"
+      },
+      {
+        "type": "slider",
+        "startTime": "14.58",
+        "endTime": "14.92",
+        "note": "k"
+      },
+      {
+        "time": "15.50",
+        "note": "j"
+      },
+      {
+        "time": "15.54",
+        "note": "d"
+      },
+      {
+        "time": "16.16",
+        "note": "f"
+      },
+      {
+        "time": "16.21",
+        "note": "k"
+      },
+      {
+        "type": "slider",
+        "startTime": "16.64",
+        "endTime": "16.96",
+        "note": "j"
+      },
+      {
+        "type": "slider",
+        "startTime": "16.63",
+        "endTime": "17.23",
+        "note": "d"
+      },
+      {
+        "type": "slider",
+        "startTime": "17.20",
+        "endTime": "17.56",
+        "note": "k"
+      },
+      {
+        "type": "slider",
+        "startTime": "17.44",
+        "endTime": "17.77",
+        "note": "f"
+      },
+      {
+        "type": "slider",
+        "startTime": "17.72",
+        "endTime": "18.02",
+        "note": "j"
+      },
+      {
+        "time": "18.20",
+        "note": "f"
+      },
+      {
+        "time": "18.36",
+        "note": "k"
+      },
+      {
+        "time": "18.45",
+        "note": "f"
+      },
+      {
+        "time": "18.62",
+        "note": "j"
+      },
+      {
+        "time": "18.98",
+        "note": "k"
+      },
+      {
+        "time": "19.00",
+        "note": "d"
+      },
+      {
+        "time": "19.38",
+        "note": "f"
+      },
+      {
+        "time": "19.40",
+        "note": "j"
+      },
+      {
+        "time": "19.64",
+        "note": "d"
+      },
+      {
+        "time": "19.67",
+        "note": "k"
+      },
+      {
+        "time": "19.91",
+        "note": "f"
+      },
+      {
+        "time": "19.94",
+        "note": "j"
+      },
+      {
+        "time": "20.18",
+        "note": "d"
+      },
+      {
+        "time": "20.20",
+        "note": "k"
+      },
+      {
+        "time": "20.43",
+        "note": "f"
+      },
+      {
+        "time": "20.47",
+        "note": "j"
+      },
+      {
+        "time": "20.70",
+        "note": "f"
+      },
+      {
+        "time": "20.74",
+        "note": "k"
+      },
+      {
+        "time": "20.98",
+        "note": "d"
+      },
+      {
+        "time": "21.00",
+        "note": "j"
+      },
+      {
+        "time": "21.25",
+        "note": "f"
+      },
+      {
+        "time": "21.28",
+        "note": "k"
+      },
+      {
+        "time": "21.52",
+        "note": "d"
+      },
+      {
+        "time": "21.52",
+        "note": "j"
+      },
+      {
+        "time": "21.80",
+        "note": "f"
+      },
+      {
+        "time": "21.81",
+        "note": "k"
+      },
+      {
+        "time": "22.06",
+        "note": "j"
+      },
+      {
+        "time": "22.08",
+        "note": "d"
+      },
+      {
+        "time": "22.32",
+        "note": "f"
+      },
+      {
+        "time": "22.34",
+        "note": "k"
+      },
+      {
+        "time": "22.60",
+        "note": "d"
+      },
+      {
+        "time": "22.61",
+        "note": "j"
+      },
+      {
+        "time": "22.85",
+        "note": "f"
+      },
+      {
+        "time": "22.89",
+        "note": "k"
+      },
+      {
+        "time": "23.11",
+        "note": "j"
+      },
+      {
+        "time": "23.14",
+        "note": "d"
+      },
+      {
+        "time": "23.40",
+        "note": "f"
+      },
+      {
+        "time": "23.43",
+        "note": "k"
+      },
+      {
+        "time": "23.66",
+        "note": "j"
+      },
+      {
+        "time": "23.68",
+        "note": "d"
+      },
+      {
+        "time": "23.93",
+        "note": "f"
+      },
+      {
+        "time": "23.95",
+        "note": "k"
+      },
+      {
+        "time": "24.20",
+        "note": "j"
+      },
+      {
+        "time": "24.22",
+        "note": "d"
+      },
+      {
+        "type": "slider",
+        "startTime": "24.30",
+        "endTime": "24.60",
+        "note": "f"
+      },
+      {
+        "type": "slider",
+        "startTime": "24.56",
+        "endTime": "24.94",
+        "note": "k"
+      },
+      {
+        "type": "slider",
+        "startTime": "24.80",
+        "endTime": "25.37",
+        "note": "d"
+      },
+      {
+        "type": "slider",
+        "startTime": "25.07",
+        "endTime": "25.70",
+        "note": "j"
+      },
+      {
+        "type": "slider",
+        "startTime": "25.61",
+        "endTime": "26.03",
+        "note": "f"
+      },
+      {
+        "type": "slider",
+        "startTime": "25.88",
+        "endTime": "27.22",
+        "note": "k"
+      },
+      {
+        "time": "27.50",
+        "note": "d"
+      },
+      {
+        "type": "slider",
+        "startTime": "27.48",
+        "endTime": "27.88",
+        "note": "j"
+      },
+      {
+        "type": "slider",
+        "startTime": "27.75",
+        "endTime": "28.13",
+        "note": "f"
+      },
+      {
+        "type": "slider",
+        "startTime": "28.02",
+        "endTime": "28.36",
+        "note": "k"
+      },
+      {
+        "type": "slider",
+        "startTime": "28.28",
+        "endTime": "28.63",
+        "note": "f"
+      },
+      {
+        "type": "slider",
+        "startTime": "28.55",
+        "endTime": "28.94",
+        "note": "j"
+      },
+      {
+        "type": "slider",
+        "startTime": "28.79",
+        "endTime": "29.34",
+        "note": "d"
+      },
+      {
+        "type": "slider",
+        "startTime": "29.07",
+        "endTime": "29.74",
+        "note": "j"
+      },
+      {
+        "type": "slider",
+        "startTime": "29.62",
+        "endTime": "29.95",
+        "note": "f"
+      },
+      {
+        "type": "slider",
+        "startTime": "29.86",
+        "endTime": "30.32",
+        "note": "k"
+      },
+      {
+        "type": "slider",
+        "startTime": "30.13",
+        "endTime": "30.91",
+        "note": "d"
+      },
+      {
+        "type": "slider",
+        "startTime": "31.50",
+        "endTime": "32.07",
+        "note": "j"
+      },
+      {
+        "type": "slider",
+        "startTime": "31.75",
+        "endTime": "32.53",
+        "note": "f"
+      },
+      {
+        "type": "slider",
+        "startTime": "32.50",
+        "endTime": "32.82",
+        "note": "j"
+      },
+      {
+        "type": "slider",
+        "startTime": "32.71",
+        "endTime": "33.04",
+        "note": "d"
+      },
+      {
+        "time": "33.24",
+        "note": "k"
+      },
+      {
+        "time": "33.63",
+        "note": "f"
+      },
+      {
+        "time": "33.64",
+        "note": "j"
+      },
+      {
+        "time": "33.90",
+        "note": "d"
+      },
+      {
+        "time": "33.94",
+        "note": "k"
+      },
+      {
+        "time": "34.19",
+        "note": "f"
+      },
+      {
+        "time": "34.20",
+        "note": "j"
+      },
+      {
+        "time": "34.43",
+        "note": "f"
+      },
+      {
+        "time": "34.45",
+        "note": "k"
+      },
+      {
+        "time": "34.81",
+        "note": "f"
+      },
+      {
+        "time": "34.83",
+        "note": "k"
+      },
+      {
+        "time": "35.28",
+        "note": "j"
+      },
+      {
+        "time": "35.30",
+        "note": "d"
+      },
+      {
+        "time": "35.77",
+        "note": "j"
+      },
+      {
+        "time": "35.82",
+        "note": "d"
+      },
+      {
+        "time": "36.23",
+        "note": "d"
+      },
+      {
+        "time": "36.25",
+        "note": "j"
+      },
+      {
+        "time": "36.51",
+        "note": "d"
+      },
+      {
+        "time": "36.54",
+        "note": "j"
+      },
+      {
+        "time": "36.79",
+        "note": "d"
+      },
+      {
+        "time": "36.80",
+        "note": "j"
+      },
+      {
+        "time": "37.05",
+        "note": "d"
+      },
+      {
+        "time": "37.06",
+        "note": "j"
+      },
+      {
+        "time": "37.32",
+        "note": "f"
+      },
+      {
+        "time": "37.34",
+        "note": "k"
+      },
+      {
+        "time": "37.60",
+        "note": "f"
+      },
+      {
+        "time": "37.63",
+        "note": "j"
+      },
+      {
+        "time": "37.87",
+        "note": "k"
+      },
+      {
+        "time": "37.89",
+        "note": "d"
+      },
+      {
+        "time": "38.13",
+        "note": "f"
+      },
+      {
+        "time": "38.14",
+        "note": "j"
+      },
+      {
+        "time": "38.38",
+        "note": "d"
+      },
+      {
+        "time": "38.40",
+        "note": "k"
+      },
+      {
+        "time": "38.61",
+        "note": "f"
+      },
+      {
+        "time": "38.62",
+        "note": "j"
+      },
+      {
+        "time": "38.94",
+        "note": "d"
+      },
+      {
+        "time": "38.99",
+        "note": "k"
+      },
+      {
+        "time": "39.44",
+        "note": "j"
+      },
+      {
+        "time": "39.45",
+        "note": "f"
+      },
+      {
+        "time": "41.17",
+        "note": "k"
+      },
+      {
+        "time": "41.41",
+        "note": "d"
+      },
+      {
+        "time": "41.72",
+        "note": "j"
+      },
+      {
+        "time": "41.94",
+        "note": "f"
+      },
+      {
+        "time": "42.51",
+        "note": "k"
+      },
+      {
+        "time": "42.83",
+        "note": "f"
+      },
+      {
+        "type": "slider",
+        "startTime": "42.80",
+        "endTime": "43.30",
+        "note": "j"
+      },
+      {
+        "time": "43.52",
+        "note": "d"
+      },
+      {
+        "time": "43.66",
+        "note": "j"
+      },
+      {
+        "time": "43.81",
+        "note": "f"
+      },
+      {
+        "time": "43.95",
+        "note": "j"
+      },
+      {
+        "time": "44.13",
+        "note": "f"
+      },
+      {
+        "time": "44.41",
+        "note": "j"
+      },
+      {
+        "time": "44.69",
+        "note": "d"
+      },
+      {
+        "time": "45.01",
+        "note": "j"
+      },
+      {
+        "time": "45.85",
+        "note": "j"
+      },
+      {
+        "time": "45.97",
+        "note": "f"
+      },
+      {
+        "time": "46.13",
+        "note": "j"
+      },
+      {
+        "time": "46.26",
+        "note": "f"
+      },
+      {
+        "time": "46.55",
+        "note": "j"
+      },
+      {
+        "time": "46.81",
+        "note": "d"
+      },
+      {
+        "time": "47.21",
+        "note": "j"
+      },
+      {
+        "time": "47.47",
+        "note": "f"
+      },
+      {
+        "time": "47.63",
+        "note": "j"
+      },
+      {
+        "time": "47.91",
+        "note": "d"
+      },
+      {
+        "time": "48.00",
+        "note": "j"
+      },
+      {
+        "time": "48.14",
+        "note": "f"
+      },
+      {
+        "time": "48.45",
+        "note": "j"
+      },
+      {
+        "type": "slider",
+        "startTime": "48.41",
+        "endTime": "48.80",
+        "note": "f"
+      },
+      {
+        "time": "49.11",
+        "note": "j"
+      },
+      {
+        "time": "49.34",
+        "note": "f"
+      },
+      {
+        "time": "49.53",
+        "note": "j"
+      },
+      {
+        "time": "49.74",
+        "note": "d"
+      },
+      {
+        "time": "49.92",
+        "note": "j"
+      },
+      {
+        "time": "50.19",
+        "note": "f"
+      },
+      {
+        "time": "50.63",
+        "note": "f"
+      },
+      {
+        "time": "50.71",
+        "note": "k"
+      },
+      {
+        "time": "51.11",
+        "note": "j"
+      },
+      {
+        "time": "51.12",
+        "note": "d"
+      },
+      {
+        "time": "51.66",
+        "note": "f"
+      },
+      {
+        "time": "51.89",
+        "note": "j"
+      },
+      {
+        "time": "52.09",
+        "note": "f"
+      },
+      {
+        "time": "52.26",
+        "note": "k"
+      },
+      {
+        "time": "52.35",
+        "note": "d"
+      },
+      {
+        "time": "52.51",
+        "note": "j"
+      },
+      {
+        "time": "52.76",
+        "note": "f"
+      },
+      {
+        "time": "52.83",
+        "note": "k"
+      },
+      {
+        "time": "53.13",
+        "note": "j"
+      },
+      {
+        "time": "53.15",
+        "note": "f"
+      },
+      {
+        "time": "53.51",
+        "note": "d"
+      },
+      {
+        "time": "53.56",
+        "note": "k"
+      },
+      {
+        "time": "54.18",
+        "note": "f"
+      },
+      {
+        "time": "54.23",
+        "note": "j"
+      },
+      {
+        "time": "54.43",
+        "note": "d"
+      },
+      {
+        "time": "54.57",
+        "note": "k"
+      },
+      {
+        "time": "54.98",
+        "note": "j"
+      },
+      {
+        "type": "slider",
+        "startTime": "54.55",
+        "endTime": "55.04",
+        "note": "f"
+      },
+      {
+        "time": "55.30",
+        "note": "f"
+      },
+      {
+        "time": "55.33",
+        "note": "k"
+      },
+      {
+        "time": "55.58",
+        "note": "f"
+      },
+      {
+        "time": "55.60",
+        "note": "j"
+      },
+      {
+        "time": "55.83",
+        "note": "f"
+      },
+      {
+        "time": "55.86",
+        "note": "k"
+      },
+      {
+        "time": "56.12",
+        "note": "d"
+      },
+      {
+        "time": "56.13",
+        "note": "j"
+      },
+      {
+        "time": "56.40",
+        "note": "j"
+      },
+      {
+        "time": "56.46",
+        "note": "d"
+      },
+      {
+        "time": "56.72",
+        "note": "k"
+      },
+      {
+        "time": "56.87",
+        "note": "f"
+      },
+      {
+        "time": "57.03",
+        "note": "j"
+      },
+      {
+        "time": "57.37",
+        "note": "d"
+      },
+      {
+        "time": "57.38",
+        "note": "k"
+      },
+      {
+        "time": "57.65",
+        "note": "f"
+      },
+      {
+        "time": "57.66",
+        "note": "j"
+      },
+      {
+        "time": "58.33",
+        "note": "d"
+      },
+      {
+        "time": "58.34",
+        "note": "k"
+      },
+      {
+        "time": "58.71",
+        "note": "f"
+      },
+      {
+        "time": "58.73",
+        "note": "j"
+      },
+      {
+        "time": "59.11",
+        "note": "f"
+      },
+      {
+        "time": "59.12",
+        "note": "k"
+      },
+      {
+        "time": "59.63",
+        "note": "j"
+      },
+      {
+        "time": "59.66",
+        "note": "d"
+      },
+      {
+        "time": "60.08",
+        "note": "f"
+      },
+      {
+        "time": "60.11",
+        "note": "k"
+      },
+      {
+        "time": "60.47",
+        "note": "f"
+      },
+      {
+        "time": "60.52",
+        "note": "j"
+      },
+      {
+        "time": "60.63",
+        "note": "d"
+      },
+      {
+        "time": "60.65",
+        "note": "k"
+      },
+      {
+        "time": "60.79",
+        "note": "f"
+      },
+      {
+        "time": "60.84",
+        "note": "j"
+      },
+      {
+        "time": "60.90",
+        "note": "k"
+      },
+      {
+        "time": "60.91",
+        "note": "d"
+      }
+    ]
+  },
+  {
+    "id": 1754861361977,
+    "title": "miles test2",
+    "author": "miles",
+    "chartData": [
+      {
+        "time": "1.11",
+        "note": "f"
+      },
+      {
+        "time": "1.21",
+        "note": "j"
+      },
+      {
+        "time": "1.37",
+        "note": "d"
+      },
+      {
+        "time": "1.49",
+        "note": "k"
+      },
+      {
+        "time": "1.57",
+        "note": "f"
+      },
+      {
+        "time": "1.76",
+        "note": "d"
+      },
+      {
+        "time": "1.86",
+        "note": "k"
+      },
+      {
+        "time": "2.38",
+        "note": "f"
+      },
+      {
+        "time": "2.39",
+        "note": "j"
+      },
+      {
+        "time": "2.78",
+        "note": "d"
+      },
+      {
+        "time": "2.84",
+        "note": "k"
+      },
+      {
+        "time": "3.04",
+        "note": "f"
+      },
+      {
+        "time": "3.05",
+        "note": "j"
+      },
+      {
+        "time": "3.27",
+        "note": "d"
+      },
+      {
+        "time": "3.30",
+        "note": "k"
+      },
+      {
+        "time": "3.51",
+        "note": "j"
+      },
+      {
+        "time": "3.52",
+        "note": "f"
+      },
+      {
+        "time": "3.72",
+        "note": "f"
+      },
+      {
+        "time": "3.80",
+        "note": "k"
+      },
+      {
+        "time": "4.16",
+        "note": "d"
+      },
+      {
+        "time": "4.17",
+        "note": "j"
+      },
+      {
+        "time": "4.60",
+        "note": "f"
+      },
+      {
+        "time": "4.64",
+        "note": "k"
+      },
+      {
+        "time": "5.07",
+        "note": "d"
+      },
+      {
+        "time": "5.10",
+        "note": "j"
+      },
+      {
+        "time": "5.52",
+        "note": "f"
+      },
+      {
+        "time": "5.55",
+        "note": "k"
+      },
+      {
+        "time": "5.74",
+        "note": "d"
+      },
+      {
+        "time": "5.76",
+        "note": "j"
+      },
+      {
+        "time": "6.27",
+        "note": "f"
+      },
+      {
+        "time": "6.29",
+        "note": "k"
+      },
+      {
+        "time": "6.48",
+        "note": "f"
+      },
+      {
+        "time": "6.53",
+        "note": "k"
+      },
+      {
+        "time": "6.71",
+        "note": "f"
+      },
+      {
+        "time": "7.10",
+        "note": "k"
+      },
+      {
+        "time": "7.29",
+        "note": "d"
+      },
+      {
+        "time": "7.49",
+        "note": "j"
+      },
+      {
+        "time": "7.68",
+        "note": "f"
+      },
+      {
+        "time": "7.95",
+        "note": "k"
+      },
+      {
+        "time": "8.29",
+        "note": "d"
+      },
+      {
+        "time": "8.32",
+        "note": "j"
+      },
+      {
+        "time": "8.79",
+        "note": "f"
+      },
+      {
+        "time": "8.85",
+        "note": "k"
+      },
+      {
+        "time": "9.22",
+        "note": "d"
+      },
+      {
+        "time": "9.27",
+        "note": "j"
+      },
+      {
+        "time": "9.48",
+        "note": "f"
+      },
+      {
+        "time": "9.52",
+        "note": "k"
+      },
+      {
+        "time": "9.97",
+        "note": "d"
+      },
+      {
+        "time": "10.03",
+        "note": "j"
+      },
+      {
+        "time": "10.44",
+        "note": "f"
+      },
+      {
+        "time": "10.48",
+        "note": "k"
+      },
+      {
+        "time": "10.61",
+        "note": "f"
+      },
+      {
+        "time": "10.70",
+        "note": "j"
+      },
+      {
+        "time": "10.86",
+        "note": "f"
+      },
+      {
+        "time": "10.95",
+        "note": "k"
+      },
+      {
+        "time": "11.13",
+        "note": "d"
+      },
+      {
+        "time": "11.15",
+        "note": "j"
+      },
+      {
+        "time": "11.42",
+        "note": "k"
+      },
+      {
+        "time": "11.63",
+        "note": "f"
+      },
+      {
+        "time": "11.63",
+        "note": "j"
+      },
+      {
+        "time": "12.02",
+        "note": "d"
+      },
+      {
+        "time": "12.07",
+        "note": "k"
+      },
+      {
+        "time": "12.48",
+        "note": "f"
+      },
+      {
+        "time": "12.51",
+        "note": "j"
+      },
+      {
+        "time": "12.90",
+        "note": "d"
+      },
+      {
+        "time": "12.95",
+        "note": "k"
+      },
+      {
+        "time": "13.15",
+        "note": "f"
+      },
+      {
+        "time": "13.18",
+        "note": "j"
+      },
+      {
+        "time": "13.61",
+        "note": "d"
+      },
+      {
+        "time": "13.63",
+        "note": "k"
+      },
+      {
+        "time": "13.85",
+        "note": "f"
+      },
+      {
+        "time": "13.87",
+        "note": "j"
+      },
+      {
+        "time": "14.10",
+        "note": "d"
+      },
+      {
+        "time": "14.13",
+        "note": "k"
+      },
+      {
+        "time": "14.32",
+        "note": "f"
+      },
+      {
+        "time": "14.36",
+        "note": "j"
+      },
+      {
+        "time": "14.60",
+        "note": "d"
+      },
+      {
+        "time": "14.61",
+        "note": "k"
+      },
+      {
+        "time": "14.85",
+        "note": "f"
+      },
+      {
+        "time": "14.86",
+        "note": "j"
+      },
+      {
+        "time": "15.12",
+        "note": "k"
+      },
+      {
+        "time": "15.13",
+        "note": "d"
+      },
+      {
+        "time": "15.33",
+        "note": "j"
+      },
+      {
+        "time": "15.37",
+        "note": "f"
+      },
+      {
+        "time": "15.60",
+        "note": "d"
+      },
+      {
+        "time": "15.61",
+        "note": "k"
+      },
+      {
+        "time": "15.80",
+        "note": "f"
+      },
+      {
+        "time": "15.82",
+        "note": "j"
+      },
+      {
+        "time": "16.01",
+        "note": "d"
+      },
+      {
+        "time": "16.06",
+        "note": "k"
+      },
+      {
+        "time": "16.21",
+        "note": "f"
+      },
+      {
+        "time": "16.25",
+        "note": "j"
+      },
+      {
+        "time": "16.62",
+        "note": "f"
+      },
+      {
+        "time": "16.66",
+        "note": "k"
+      },
+      {
+        "time": "16.84",
+        "note": "d"
+      },
+      {
+        "time": "16.86",
+        "note": "j"
+      },
+      {
+        "time": "17.30",
+        "note": "d"
+      },
+      {
+        "time": "17.36",
+        "note": "k"
+      },
+      {
+        "time": "17.55",
+        "note": "f"
+      },
+      {
+        "time": "17.59",
+        "note": "j"
+      },
+      {
+        "time": "17.80",
+        "note": "d"
+      },
+      {
+        "time": "17.85",
+        "note": "k"
+      },
+      {
+        "time": "18.02",
+        "note": "f"
+      },
+      {
+        "time": "18.07",
+        "note": "j"
+      },
+      {
+        "time": "18.27",
+        "note": "d"
+      },
+      {
+        "time": "18.31",
+        "note": "k"
+      },
+      {
+        "time": "18.50",
+        "note": "f"
+      },
+      {
+        "time": "18.54",
+        "note": "j"
+      },
+      {
+        "time": "18.76",
+        "note": "d"
+      },
+      {
+        "time": "18.79",
+        "note": "k"
+      },
+      {
+        "time": "19.01",
+        "note": "f"
+      },
+      {
+        "time": "19.03",
+        "note": "j"
+      },
+      {
+        "time": "19.22",
+        "note": "d"
+      },
+      {
+        "time": "19.28",
+        "note": "k"
+      },
+      {
+        "time": "19.48",
+        "note": "d"
+      },
+      {
+        "time": "19.52",
+        "note": "j"
+      },
+      {
+        "time": "19.71",
+        "note": "f"
+      },
+      {
+        "time": "19.77",
+        "note": "k"
+      },
+      {
+        "time": "20.07",
+        "note": "d"
+      },
+      {
+        "time": "20.10",
+        "note": "j"
+      },
+      {
+        "time": "20.52",
+        "note": "f"
+      },
+      {
+        "time": "20.56",
+        "note": "k"
+      },
+      {
+        "time": "20.99",
+        "note": "d"
+      },
+      {
+        "time": "21.00",
+        "note": "j"
+      },
+      {
+        "time": "21.45",
+        "note": "f"
+      },
+      {
+        "time": "21.47",
+        "note": "k"
+      },
+      {
+        "time": "21.70",
+        "note": "f"
+      },
+      {
+        "time": "21.75",
+        "note": "j"
+      },
+      {
+        "time": "21.93",
+        "note": "d"
+      },
+      {
+        "time": "21.99",
+        "note": "k"
+      },
+      {
+        "time": "22.19",
+        "note": "d"
+      },
+      {
+        "time": "22.40",
+        "note": "f"
+      },
+      {
+        "time": "22.44",
+        "note": "j"
+      },
+      {
+        "time": "22.62",
+        "note": "f"
+      },
+      {
+        "time": "22.69",
+        "note": "k"
+      },
+      {
+        "time": "22.86",
+        "note": "d"
+      },
+      {
+        "time": "22.89",
+        "note": "j"
+      },
+      {
+        "time": "23.09",
+        "note": "f"
+      },
+      {
+        "time": "23.14",
+        "note": "k"
+      },
+      {
+        "time": "23.35",
+        "note": "d"
+      },
+      {
+        "time": "23.39",
+        "note": "k"
+      },
+      {
+        "time": "23.79",
+        "note": "f"
+      },
+      {
+        "time": "23.82",
+        "note": "j"
+      },
+      {
+        "time": "24.25",
+        "note": "d"
+      },
+      {
+        "time": "24.29",
+        "note": "k"
+      },
+      {
+        "time": "24.70",
+        "note": "f"
+      },
+      {
+        "time": "24.73",
+        "note": "j"
+      },
+      {
+        "time": "24.93",
+        "note": "d"
+      },
+      {
+        "time": "24.98",
+        "note": "k"
+      },
+      {
+        "time": "25.21",
+        "note": "f"
+      },
+      {
+        "time": "25.24",
+        "note": "j"
+      },
+      {
+        "time": "25.43",
+        "note": "f"
+      },
+      {
+        "time": "25.47",
+        "note": "k"
+      },
+      {
+        "time": "25.65",
+        "note": "d"
+      },
+      {
+        "time": "25.70",
+        "note": "j"
+      }
+    ]
   }
 ]

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -124,7 +124,6 @@
       "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.1.1.tgz",
       "integrity": "sha512-AGBHOG5hPYZ5Xl9KXzU5iKq9516yEmvCKDg3ecP5kX2aB6UqTeXZxk2ELnDgDm6BQSMlLt9rDB4LoSMx0rYwww==",
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.11",
         "node-addon-api": "^5.0.0"
@@ -137,7 +136,6 @@
       "version": "1.20.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
       "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
-      "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "content-type": "~1.0.5",
@@ -281,7 +279,6 @@
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-      "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -426,7 +423,6 @@
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
-      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -767,7 +763,6 @@
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
       "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
-      "license": "MIT",
       "dependencies": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,11 @@
       "name": "rhythm-game-backend",
       "version": "1.0.0",
       "dependencies": {
-        "bcrypt": "^5.1.0",
-        "body-parser": "^1.20.2",
+        "bcrypt": "^5.1.1",
+        "body-parser": "^1.20.3",
         "cors": "^2.8.5",
-        "express": "^4.18.2",
-        "jsonwebtoken": "^9.0.0"
+        "express": "^4.21.2",
+        "jsonwebtoken": "^9.0.2"
       },
       "engines": {
         "node": ">=16"
@@ -138,7 +138,6 @@
       "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.1.1.tgz",
       "integrity": "sha512-AGBHOG5hPYZ5Xl9KXzU5iKq9516yEmvCKDg3ecP5kX2aB6UqTeXZxk2ELnDgDm6BQSMlLt9rDB4LoSMx0rYwww==",
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.11",
         "node-addon-api": "^5.0.0"
@@ -151,7 +150,6 @@
       "version": "1.20.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
       "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
-      "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "content-type": "~1.0.5",
@@ -295,7 +293,6 @@
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-      "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -440,7 +437,6 @@
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
-      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -781,7 +777,6 @@
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
       "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
-      "license": "MIT",
       "dependencies": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -7,11 +7,11 @@
     "start": "node server.js"
   },
   "dependencies": {
-    "bcrypt": "^5.1.0",
-    "body-parser": "^1.20.2",
+    "bcrypt": "^5.1.1",
+    "body-parser": "^1.20.3",
     "cors": "^2.8.5",
-    "express": "^4.18.2",
-    "jsonwebtoken": "^9.0.0"
+    "express": "^4.21.2",
+    "jsonwebtoken": "^9.0.2"
   },
   "engines": {
     "node": ">=16"

--- a/play.html
+++ b/play.html
@@ -93,32 +93,43 @@
     const keyStates = {};
 
     // Load map data from URL
-    function loadMapData(chartData) {
+    function loadMapDataFromText(text) {
       notes = [];
       sliders = [];
-      chartData.forEach(note => {
-        if (note.type === 'slider') {
+      let songUrl = '';
+      const lines = text.split('\n');
+      for (const line of lines) {
+        if (line.startsWith('Song:')) {
+          songUrl = line.replace('Song:', '').trim();
+          continue;
+        }
+        const noteMatch = line.match(/Time: ([\d.]+), Note: (\w+)/);
+        if (noteMatch) {
+          notes.push({
+            time: parseFloat(noteMatch[1]),
+            key: noteMatch[2],
+            hit: false,
+          });
+          continue;
+        }
+        const sliderMatch = line.match(/Slider: StartTime: ([\d.]+), EndTime: ([\d.]+), Key: (\w+)/);
+        if (sliderMatch) {
           sliders.push({
-            startTime: parseFloat(note.startTime),
-            endTime: parseFloat(note.endTime),
-            key: note.note,
+            startTime: parseFloat(sliderMatch[1]),
+            endTime: parseFloat(sliderMatch[2]),
+            key: sliderMatch[3],
             hit: false,
             active: false,
           });
-        } else {
-          notes.push({
-            time: parseFloat(note.time),
-            key: note.note,
-            hit: false,
-          });
         }
-      });
+      }
+      setAudioSource(songUrl);
     }
 
     // Set audio source from song URL parameter
-    function setAudioSource() {
-      let songUrl = getSongUrlFromUrl();
-      console.log("Song URL parameter:", songUrl);
+    function setAudioSource(songUrlOverride) {
+      let songUrl = songUrlOverride || getSongUrlFromUrl();
+      console.log("Song URL:", songUrl);
       const playButton = document.getElementById('playButton');
       if (!songUrl) {
         // Fallback to default song if no song URL provided
@@ -531,9 +542,28 @@
     window.addEventListener('load', () => {
       const params = new URLSearchParams(window.location.search);
       const mapId = params.get('mapId');
+      const chartFile = params.get('chartFile');
       const autoplay = params.get('autoplay') === 'true';
 
-      if (mapId) {
+      if (chartFile) {
+        // Load chart from text file
+        fetch(chartFile)
+          .then(response => response.text())
+          .then(text => {
+            loadMapDataFromText(text);
+            if (autoplay) {
+              startGame();
+              const playButton = document.getElementById('playButton');
+              playButton.disabled = true;
+              playButton.style.opacity = 0.5;
+              playButton.style.cursor = 'default';
+            }
+          })
+          .catch(e => {
+            alert('Failed to load chart file.');
+            console.error(e);
+          });
+      } else if (mapId) {
         fetch('/api/maps')
           .then(response => response.json())
           .then(maps => {
@@ -561,7 +591,8 @@
                 });
               }
             });
-            setAudioSource();
+            // Use map.song if present, otherwise fallback
+            setAudioSource(map.song);
             if (autoplay) {
               startGame();
               const playButton = document.getElementById('playButton');
@@ -575,7 +606,7 @@
             console.error(e);
           });
       } else {
-        alert('No mapId parameter provided.');
+        alert('No mapId or chartFile parameter provided.');
       }
     });
 

--- a/signup.html
+++ b/signup.html
@@ -94,7 +94,7 @@
       }
 
       try {
-        const response = await fetch('https://bug-free-space-succotash-q77746g7pjrhx47p-3001.app.github.dev/api/signup', {
+        const response = await fetch('https://psychic-space-winner-wp6r9r97qv6hvgw4-3001.app.github.dev/api/signup', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ username, password })


### PR DESCRIPTION
- Updated bcrypt to version 5.1.1, body-parser to version 1.20.3, express to version 4.21.2, and jsonwebtoken to version 9.0.2 in package.json and package-lock.json.
- Removed license fields from package-lock.json and .package-lock.json for various dependencies.
- Refactored loadMapData function to load map data from a text file, allowing for song URL extraction and note parsing.
- Enhanced setAudioSource function to accept an optional song URL parameter.
- Updated the logic in the window load event to handle chart file loading and fallback to mapId if chartFile is not provided.
- Changed the signup API endpoint URL in signup.html to a new address.